### PR TITLE
Herokufix 2: Electric Boogaloo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run serve
+web: npm start

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A management utility for the NZ Crucible LARP.",
   "main": "gulpfile.js",
   "scripts": {
-    "serve": "node src/server/server.js",
+    "start": "gulp build && node src/server/server.js",
     "test": "gulp test",
     "debug": "gulp run",
     "build": "gulp build"

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* globals require, env, __dirname */
+/* globals require, $PORT, __dirname */
 
 var http = require('http');
 var socket = require('ws');
@@ -16,12 +16,9 @@ var config = {
 	port: 8000
 };
 
-if (typeof(env) !== 'undefined') {
-
-	if (typeof(env['$PORT']) !== 'undefined') {
-		config.port = env['$PORT'];
-	}
-
+// bind to the heroku-specified port var.
+if (typeof($PORT) !== 'undefined') {
+	config.port = $PORT;
 }
 
 var app = express();


### PR DESCRIPTION
Apparently heroku doesn't use env.$PORT, and instead uses straight-old-$PORT. At least that's what I'm assuming it does. If this doesn't work, I'll look up what kind of environment variables get passed along.