### PR TITLE
Herokufix 3: Revenge of the Herokufix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A management utility for the NZ Crucible LARP.",
   "main": "gulpfile.js",
   "scripts": {
-    "start": "gulp build && node src/server/server.js",
+    "postinstall": "gulp build",
+    "start": "node src/server/server.js",
     "test": "gulp test",
-    "debug": "gulp run",
-    "build": "gulp build"
+    "debug": "gulp run"
   },
   "repository": {
     "type": "git",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* globals require, $PORT, __dirname */
+/* globals require, process, __dirname */
 
 var http = require('http');
 var socket = require('ws');
@@ -13,13 +13,11 @@ var fileStorage = new swarm.FileStorage('storage');
 var swarmHost = new swarm.Host('swarm~nodejs', 0, fileStorage);
 
 var config = {
-	port: 8000
+	port: process.env['PORT'] || 8000,
+	mongo: {
+		uri: process.env['MONGOLAB_URI'] || 'mongodb://localhost:4000'
+	}
 };
-
-// bind to the heroku-specified port var.
-if (typeof($PORT) !== 'undefined') {
-	config.port = $PORT;
-}
 
 var app = express();
 
@@ -48,4 +46,6 @@ wsServer.on('connection', function (ws) {
 
 //require('./static/user-data.js');
 
-app.listen(config.port);
+app.listen(config.port, function() {
+	console.log('Starting application on port ' + config.port);
+});


### PR DESCRIPTION
With all the documentation I looked at, this seemed to be the way to go. If the postinstall script fails, I'm not sure exactly what Heroku are expecting when it comes to gulp usage. I guess I'll have to move the gulp dependencies to the runtime set, rather than just the dev set. Seems a bit silly.